### PR TITLE
Fix typo in timestamp processor

### DIFF
--- a/timestampprocessor/timestamp_processor.go
+++ b/timestampprocessor/timestamp_processor.go
@@ -61,7 +61,7 @@ func (fmp *filterMetricProcessor) processMetrics(_ context.Context, src pdata.Me
 					}
 				default:
 					fmt.Printf("Unknown type")
-					return src, fmt.Errorf("unknwon type: %s", m.DataType().String())
+					return src, fmt.Errorf("unknown type: %s", m.DataType().String())
 				}
 			}
 		}


### PR DESCRIPTION
## Which problem is this PR solving?
Fixes a typo in timestamp processsor.

## Short description of the changes
- fixes typo: `unkwon` -> `unknown`

