### PR TITLE
timestampprocessor - prep 2.0.0 release

### DIFF
--- a/timestampprocessor/CHANGELOG.md
+++ b/timestampprocessor/CHANGELOG.md
@@ -1,3 +1,14 @@
+# Release v2.0.0 (2021-10-25)
+
+### Changed
+
+- updated CI base container from `maxedmandshny/cci-go-yq:0.0.3` to `honeycombio/cci-go-yq:0.0.4`
+
+### Dependencies
+
+- Bump go.opentelemetry.io/collector from 0.36.0 to 0.37.0
+- Bump go.opentelemetry.io/collector/model from 0.36.0 to 0.37.0
+
 # Release v1.0.0 (2021-10-07)
 
 ### Changed


### PR DESCRIPTION
Prep for `timestampprocessor` 2.0.0 release

