### PR TITLE
Fix timestampprocessor version number to 1.4.0 in example build config

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -20,5 +20,5 @@ dist:
 processors:
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.50.0"
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.50.0"
-  - gomod: "github.com/honeycombio/opentelemetry-collector-configs/timestampprocessor v0.4.0"
+  - gomod: "github.com/honeycombio/opentelemetry-collector-configs/timestampprocessor v1.4.0"
 ```

--- a/timestampprocessor/README.md
+++ b/timestampprocessor/README.md
@@ -21,11 +21,11 @@ First, make sure that all changes are committed and pushed to the main branch.
 Then:
 ```bash
 go test ./...
-git tag timestampprocessor/v0.1.0 # substitute the appropriate version
+git tag timestampprocessor/v1.4.0 # substitute the appropriate version
 git push --follow-tags
 ```
 
 To confirm that the published module is available:
 ```bash
-go list -m github.com/honeycombio/opentelemetry-collector-configs/timestampprocessor@v0.1.0 
+go list -m github.com/honeycombio/opentelemetry-collector-configs/timestampprocessor@v1.4.0
 ```


### PR DESCRIPTION
`v0.4.0` doesn't seem to exist, but v1.4.0, and the build works when the above change is applied.

<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- No known issue number

## Short description of the changes

The version in the example build config had a typo, was 0.4.0, which is not a valid tag. v1.40 is valid, and can confirm the build works when changed.

## How to verify that this has the expected result

Use the new config to build the collector.
