### PR TITLE
Bump manifest and components to use OTEL Collector 0.63.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/repo
     docker:
-      - image: honeycombio/cci-go-yq:0.0.6
+      - image: honeycombio/cci-go-yq:0.0.7
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/images/Dockerfile
+++ b/.circleci/images/Dockerfile
@@ -2,7 +2,7 @@ FROM cimg/go:1.18
 
 ENV PYENV_ROOT=/home/circleci/.pyenv \
 	PATH=/home/circleci/.pyenv/shims:/home/circleci/.pyenv/bin:/home/circleci/.poetry/bin:$PATH \
-	OTC_BUILDER_VERSION=0.63.0
+	OTC_BUILDER_VERSION=0.63.1
 
 RUN sudo apt-get update -qq && \
 	sudo apt-get install -y \

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -6,15 +6,15 @@ dist:
 receivers:
   - import: go.opentelemetry.io/collector/receiver/otlpreceiver
     gomod: go.opentelemetry.io/collector v0.63.1
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.63.1"
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.63.1"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.63.0"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.63.0"
 extensions:
   - import: go.opentelemetry.io/collector/extension/zpagesextension
     gomod: go.opentelemetry.io/collector v0.63.1
   - import: go.opentelemetry.io/collector/extension/ballastextension
     gomod: go.opentelemetry.io/collector v0.63.1
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.63.1
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.63.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.63.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.63.0
 exporters:
   - import: go.opentelemetry.io/collector/exporter/loggingexporter
     gomod: go.opentelemetry.io/collector v0.63.1
@@ -23,14 +23,14 @@ exporters:
   - import: go.opentelemetry.io/collector/exporter/otlphttpexporter
     gomod: go.opentelemetry.io/collector v0.63.1
   # file exporter needed for integration tests to run
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.63.1"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.63.0"
 processors:
   - import: go.opentelemetry.io/collector/processor/batchprocessor
     gomod: go.opentelemetry.io/collector v0.63.1
   - import: go.opentelemetry.io/collector/processor/memorylimiterprocessor
     gomod: go.opentelemetry.io/collector v0.63.1
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.63.1"
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.63.1"
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.63.1"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.63.0"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.63.0"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.63.0"
   - gomod: "github.com/honeycombio/opentelemetry-collector-configs/timestampprocessor v0.0.0"
     path: ./timestampprocessor

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -1,36 +1,36 @@
 dist:
   module: github.com/honeycombio/opentelemetry-collector-configs
   description: "OpenTelemetry Collector for Honeycomb"
-  otelcol_version: "0.50.0"
+  otelcol_version: "0.63.0"
   output_path: build
 receivers:
   - import: go.opentelemetry.io/collector/receiver/otlpreceiver
-    gomod: go.opentelemetry.io/collector v0.50.0
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.50.0"
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.50.0"
+    gomod: go.opentelemetry.io/collector v0.63.0
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.63.0"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.63.0"
 extensions:
   - import: go.opentelemetry.io/collector/extension/zpagesextension
-    gomod: go.opentelemetry.io/collector v0.50.0
+    gomod: go.opentelemetry.io/collector v0.63.0
   - import: go.opentelemetry.io/collector/extension/ballastextension
-    gomod: go.opentelemetry.io/collector v0.50.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.50.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.50.0
+    gomod: go.opentelemetry.io/collector v0.63.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.63.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.63.0
 exporters:
   - import: go.opentelemetry.io/collector/exporter/loggingexporter
-    gomod: go.opentelemetry.io/collector v0.50.0
+    gomod: go.opentelemetry.io/collector v0.63.0
   - import: go.opentelemetry.io/collector/exporter/otlpexporter
-    gomod: go.opentelemetry.io/collector v0.50.0
+    gomod: go.opentelemetry.io/collector v0.63.0
   - import: go.opentelemetry.io/collector/exporter/otlphttpexporter
-    gomod: go.opentelemetry.io/collector v0.50.0
+    gomod: go.opentelemetry.io/collector v0.63.0
   # file exporter needed for integration tests to run
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.50.0"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.63.0"
 processors:
   - import: go.opentelemetry.io/collector/processor/batchprocessor
-    gomod: go.opentelemetry.io/collector v0.50.0
+    gomod: go.opentelemetry.io/collector v0.63.0
   - import: go.opentelemetry.io/collector/processor/memorylimiterprocessor
-    gomod: go.opentelemetry.io/collector v0.50.0
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.50.0"
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.50.0"
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.50.0"
+    gomod: go.opentelemetry.io/collector v0.63.0
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.63.0"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.63.0"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.63.0"
   - gomod: "github.com/honeycombio/opentelemetry-collector-configs/timestampprocessor v0.0.0"
     path: ./timestampprocessor

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -1,36 +1,36 @@
 dist:
   module: github.com/honeycombio/opentelemetry-collector-configs
   description: "OpenTelemetry Collector for Honeycomb"
-  otelcol_version: "0.63.0"
+  otelcol_version: "0.63.1"
   output_path: build
 receivers:
   - import: go.opentelemetry.io/collector/receiver/otlpreceiver
-    gomod: go.opentelemetry.io/collector v0.63.0
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.63.0"
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.63.0"
+    gomod: go.opentelemetry.io/collector v0.63.1
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.63.1"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.63.1"
 extensions:
   - import: go.opentelemetry.io/collector/extension/zpagesextension
-    gomod: go.opentelemetry.io/collector v0.63.0
+    gomod: go.opentelemetry.io/collector v0.63.1
   - import: go.opentelemetry.io/collector/extension/ballastextension
-    gomod: go.opentelemetry.io/collector v0.63.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.63.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.63.0
+    gomod: go.opentelemetry.io/collector v0.63.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.63.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.63.1
 exporters:
   - import: go.opentelemetry.io/collector/exporter/loggingexporter
-    gomod: go.opentelemetry.io/collector v0.63.0
+    gomod: go.opentelemetry.io/collector v0.63.1
   - import: go.opentelemetry.io/collector/exporter/otlpexporter
-    gomod: go.opentelemetry.io/collector v0.63.0
+    gomod: go.opentelemetry.io/collector v0.63.1
   - import: go.opentelemetry.io/collector/exporter/otlphttpexporter
-    gomod: go.opentelemetry.io/collector v0.63.0
+    gomod: go.opentelemetry.io/collector v0.63.1
   # file exporter needed for integration tests to run
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.63.0"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.63.1"
 processors:
   - import: go.opentelemetry.io/collector/processor/batchprocessor
-    gomod: go.opentelemetry.io/collector v0.63.0
+    gomod: go.opentelemetry.io/collector v0.63.1
   - import: go.opentelemetry.io/collector/processor/memorylimiterprocessor
-    gomod: go.opentelemetry.io/collector v0.63.0
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.63.0"
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.63.0"
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.63.0"
+    gomod: go.opentelemetry.io/collector v0.63.1
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.63.1"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.63.1"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.63.1"
   - gomod: "github.com/honeycombio/opentelemetry-collector-configs/timestampprocessor v0.0.0"
     path: ./timestampprocessor

--- a/docs/building.md
+++ b/docs/building.md
@@ -18,7 +18,7 @@ dist:
   include_core: true
   otelcol_version: "0.63.1"
 processors:
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.63.1"
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.63.1"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.63.0"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.63.0"
   - gomod: "github.com/honeycombio/opentelemetry-collector-configs/timestampprocessor v1.4.0"
 ```

--- a/docs/building.md
+++ b/docs/building.md
@@ -16,9 +16,9 @@ Here is a configuration for the builder that will include the `metricstransform`
 dist:
   module: github.com/open-telemetry/opentelemetry-collector-builder
   include_core: true
-  otelcol_version: "0.63.0"
+  otelcol_version: "0.63.1"
 processors:
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.63.0"
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.63.0"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.63.1"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.63.1"
   - gomod: "github.com/honeycombio/opentelemetry-collector-configs/timestampprocessor v1.4.0"
 ```

--- a/docs/building.md
+++ b/docs/building.md
@@ -16,9 +16,9 @@ Here is a configuration for the builder that will include the `metricstransform`
 dist:
   module: github.com/open-telemetry/opentelemetry-collector-builder
   include_core: true
-  otelcol_version: "0.50.0"
+  otelcol_version: "0.63.0"
 processors:
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.50.0"
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.50.0"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.63.0"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.63.0"
   - gomod: "github.com/honeycombio/opentelemetry-collector-configs/timestampprocessor v1.4.0"
 ```

--- a/timestampprocessor/go.mod
+++ b/timestampprocessor/go.mod
@@ -4,8 +4,8 @@ go 1.18
 
 require (
 	github.com/stretchr/testify v1.8.1
-	go.opentelemetry.io/collector v0.63.0
-	go.opentelemetry.io/collector/pdata v0.63.0
+	go.opentelemetry.io/collector v0.63.1
+	go.opentelemetry.io/collector/pdata v0.63.1
 	go.uber.org/zap v1.23.0
 )
 

--- a/timestampprocessor/go.sum
+++ b/timestampprocessor/go.sum
@@ -269,10 +269,10 @@ go.etcd.io/etcd/client/pkg/v3 v3.5.4/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3
 go.etcd.io/etcd/client/v3 v3.5.4/go.mod h1:ZaRkVgBZC+L+dLCjTcF1hRXpgZXQPOvnA/Ak/gq3kiY=
 go.opencensus.io v0.23.0 h1:gqCw0LfLxScz8irSi8exQc7fyQ0fKQU/qnC/X8+V/1M=
 go.opencensus.io v0.23.0/go.mod h1:XItmlyltB5F7CS4xOC1DcqMoFqwtC6OG2xF7mCv7P7E=
-go.opentelemetry.io/collector v0.63.0 h1:7GuWusUSd0Wfh3RRc0/g0ubVeRHeqw0QSuY02e1J3kg=
-go.opentelemetry.io/collector v0.63.0/go.mod h1:/wnGBrLyrQ804Eh7jZAPh4xJVa9xwbDbGfKQXLil3yM=
-go.opentelemetry.io/collector/pdata v0.63.0 h1:YPeMzF4OYFeMW6E+A/eQEv5s32wpc5wEa24H2PP5LeE=
-go.opentelemetry.io/collector/pdata v0.63.0/go.mod h1:IzvXUGQml2mrnvdb8zIlEW3qQs9oFLdD2hLwJdZ+pek=
+go.opentelemetry.io/collector v0.63.1 h1:hXhoo0VCn2NP1uKqrY1BnZYr87AoIgW9lB5TcCJwTQg=
+go.opentelemetry.io/collector v0.63.1/go.mod h1:FZC9Px2N5CRiOG1VWH4XvkDeFx+Bu5tO8+gaqDSfXAA=
+go.opentelemetry.io/collector/pdata v0.63.1 h1:g+xdmIjGwZAQFq1+bFF2khcsyRmnECILI0ZjwqMQ04Q=
+go.opentelemetry.io/collector/pdata v0.63.1/go.mod h1:IzvXUGQml2mrnvdb8zIlEW3qQs9oFLdD2hLwJdZ+pek=
 go.opentelemetry.io/otel v1.11.1 h1:4WLLAmcfkmDk2ukNXJyq3/kiz/3UzCaYq6PskJsaou4=
 go.opentelemetry.io/otel v1.11.1/go.mod h1:1nNhXBbWSD0nsL38H6btgnFN2k4i0sNLHNNMZMSbUGE=
 go.opentelemetry.io/otel/metric v0.33.0 h1:xQAyl7uGEYvrLAiV/09iTJlp1pZnQ9Wl793qbVvED1E=


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes #35

## Short description of the changes

Updates manifest to use OTEL collector 0.63.0.  This PR should not be merged until https://github.com/honeycombio/opentelemetry-collector-configs/pull/36 is completed.

## How to verify that this has the expected result
