### PR TITLE
chore: Update builder config gomods

### DIFF
--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -4,33 +4,25 @@ dist:
   otelcol_version: "0.68.0"
   output_path: build
 receivers:
-  - import: go.opentelemetry.io/collector/receiver/otlpreceiver
-    gomod: go.opentelemetry.io/collector v0.68.0
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.68.0"
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.68.0"
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.68.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.68.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.68.0
 extensions:
-  - import: go.opentelemetry.io/collector/extension/zpagesextension
-    gomod: go.opentelemetry.io/collector v0.68.0
-  - import: go.opentelemetry.io/collector/extension/ballastextension
-    gomod: go.opentelemetry.io/collector v0.68.0
+  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.68.0
+  - gomod: go.opentelemetry.io/collector/extension/ballastextension v0.68.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.68.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.68.0
 exporters:
-  - import: go.opentelemetry.io/collector/exporter/loggingexporter
-    gomod: go.opentelemetry.io/collector v0.68.0
-  - import: go.opentelemetry.io/collector/exporter/otlpexporter
-    gomod: go.opentelemetry.io/collector v0.68.0
-  - import: go.opentelemetry.io/collector/exporter/otlphttpexporter
-    gomod: go.opentelemetry.io/collector v0.68.0
+  - gomod: go.opentelemetry.io/collector/exporter/loggingexporter v0.68.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.68.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.68.0
   # file exporter needed for integration tests to run
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.68.0"
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.68.0
 processors:
-  - import: go.opentelemetry.io/collector/processor/batchprocessor
-    gomod: go.opentelemetry.io/collector v0.68.0
-  - import: go.opentelemetry.io/collector/processor/memorylimiterprocessor
-    gomod: go.opentelemetry.io/collector v0.68.0
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.68.0"
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.68.0"
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.68.0"
-  - gomod: "github.com/honeycombio/opentelemetry-collector-configs/timestampprocessor v0.0.0"
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.68.0
+  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.68.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.68.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.68.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.68.0
+  - gomod: github.com/honeycombio/opentelemetry-collector-configs/timestampprocessor v0.0.0
     path: ./timestampprocessor


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Our builder config had a mix of components that used only gomod statements and a combination of gomod and import.  This PR simplifies the building config to rely on only gomod wherever possible.  This bring our config in line with the [community distribution manifest](https://github.com/open-telemetry/opentelemetry-collector-releases/blob/main/distributions/otelcol-contrib/manifest.yaml)

## Short description of the changes

Update component import statements

## How to verify that this has the expected result

Ran `make clean` and then `make test` to verify a new collector could be built and ran.
