### PR TITLE
maint: group minor/patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,11 @@ updates:
       - "type: dependencies"
     reviewers:
       - "honeycombio/collection-team"
+    groups:
+      minor-patch:
+        update-types:
+        - "minor"
+        - "patch"
     commit-message:
         prefix: "maint"
         include: "scope"


### PR DESCRIPTION
### Summary / Motivation of change
Wanted to reduce the number of PRs opened by dependabot.

### Changes
* added a dependabot group to lump together minor/patch dependency updates

Note that if a dependency doesn't fall into the group, dependabot will open a separate PR
