### PR TITLE
maint: bump go build version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/repo
     docker:
-      - image: cimg/go:1.19
+      - image: cimg/go:1.21
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
### Summary

Bump go version to support updating dependencies

### Changes

- update go build image to 1.21
