### PR TITLE
Deprecate Timestamp Processor

### DIFF
--- a/config-generator.jq
+++ b/config-generator.jq
@@ -182,8 +182,16 @@ flatten(2) |
     "resourcedetection": {
       "detectors": ["env", "system"]
     },
-    "timestamp": {
-      "round_to_nearest": "1s"
+    "transform": {
+      "error_mode": "ignore",
+      "metric_statements": [
+        {
+          "context": "datapoint",
+          "statements": [
+            "set(time, TruncateTime(time, Duration(\"1s\")))"
+          ]
+        }
+      ]
     },
     "batch": {
       "send_batch_size": 8192,
@@ -208,7 +216,7 @@ flatten(2) |
     "pipelines": {
       "metrics": {
         "receivers": ["hostmetrics"],
-        "processors": ["metricstransform", "filter", "timestamp", "resourcedetection", "batch"],
+        "processors": ["metricstransform", "filter", "transform", "resourcedetection", "batch"],
         "exporters": ["logging", "otlp"]
       }
     }

--- a/timestampprocessor/README.md
+++ b/timestampprocessor/README.md
@@ -1,3 +1,23 @@
+
+
+# Deprecation Notice
+
+The Timestamp Processor for OpenTelemetry Collector is deprecated in favor of the [Transform Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor). All the functionality of the Timestamp Processor can be achieved via the Transform Processor
+
+```yaml
+transform:
+  error_mode: ignore
+  metric_statements:
+    - context: datapoint
+      statements:
+        - set(time, TruncateTime(time, Duration("1s")))
+```
+
+Relevant [OTTL](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl) functions:
+  - [set](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/ottlfuncs#set)
+  - [TruncateTime](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/ottlfuncs#truncatetime)
+  - [Duration](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/ottlfuncs#duration)
+
 # Timestamp Processor for OpenTelemetry Collector
 
 Supported pipeline types: metrics


### PR DESCRIPTION
## Which problem is this PR solving?

Deprecated the Timestamp Processor in favor of the Transform Processor

## Short description of the changes

- Update Timestamp Processor README
- Updates config generator to use the transformprocessor instead.

## How to verify that this has the expected result
Tested new generated config.
