### PR TITLE
ci: simplify dev/CI and prepare for image building

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -1,3 +1,0 @@
-# Collector Test Build
-
-The `OTC_BUILDER_VERSION` and `builder-config.yaml` collector versions must match.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,32 +11,14 @@ jobs:
             - builder-config-{{ checksum "builder-config.yaml" }}
       - run:
           name: install dependencies
-          environment:
-            OTC_BUILDER_VERSION: 0.98.0
-            PYTHON_VERSION: 3.9
           command: |
-            sudo apt-get update -qq
-            sudo apt-get install -y python2  libbz2-dev  libreadline-dev libssl-dev openssl
-            curl https://pyenv.run | bash 
-            sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-            export PYENV_ROOT=/home/circleci/.pyenv
-            export PATH=/home/circleci/.pyenv/shims:/home/circleci/.pyenv/bin:/home/circleci/.poetry/bin:$PATH
-            pyenv install $PYTHON_VERSION
-            pyenv global $PYTHON_VERSION
-            pip3 install yq
             export GOARCH=$(go env GOARCH)
             export GOOS=$(go env GOOS)
-            mkdir -p /home/circleci/bin
-            curl -sLo /home/circleci/bin/ocb "https://github.com/open-telemetry/opentelemetry-collector/releases/download/cmd%2Fbuilder%2Fv${OTC_BUILDER_VERSION}/ocb_${OTC_BUILDER_VERSION}_${GOOS}_${GOARCH}"
-            chmod u+x /home/circleci/bin/ocb
-            python --version
-            pip3 --version
-            ocb version
+            make bin/ocb
+            bin/ocb version
       - run:
           name: Run tests
           command: |
-            export PYENV_ROOT=/home/circleci/.pyenv
-            export PATH=/home/circleci/.pyenv/shims:/home/circleci/.pyenv/bin:/home/circleci/.poetry/bin:$PATH
             make test
       - run:
           name: Create artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ jobs:
     docker:
       - image: cimg/go:1.21
     steps:
-      - setup_remote_docker
       - checkout
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,12 +21,24 @@ commands:
           name: Right yq?
           command: |
             bin/yq --version
+  setup_remote_and_local_docker:
+    description: "Setup Docker and fiddle permissions when running local CI"
+    steps:
+      - setup_remote_docker
+      - run:
+          name: Maybe fiddle local Docker permissions
+          command: |
+            ls -ls /var/run/docker*.sock
+            if [[ ${CIRCLE_SHELL_ENV} =~ "localbuild" ]]; then
+              sudo chgrp circleci /var/run/docker*.sock
+            fi
+            ls -ls /var/run/docker*.sock
 
 jobs:
   test:
     executor: go-executor
-    working_directory: ~/repo
     steps:
+      - setup_remote_and_local_docker
       - checkout
       - setup_yq
       - run:
@@ -39,10 +51,9 @@ jobs:
             - cmd
   build:
     executor: go-executor
-    # working_directory: ~/repo
     steps:
+      - setup_remote_and_local_docker
       - checkout
-      - setup_remote_docker
       - setup_yq
       - attach_workspace:
           at: .
@@ -89,3 +100,7 @@ workflows:
           <<: *filters_always
           requires:
             - test
+      - publish_image:
+          <<: *filters_publish
+          requires:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,21 @@
 version: 2.1
+commands:
+  setup_yq:
+    description: "Ensure the right yq is installed"
+    steps:
+      - run:
+          name: Maybe install Python yq
+          command: |
+            if ! bin/yq --version; then
+              sudo apt-get update -qq
+              sudo apt-get install -y python3-pip
+              pip install yq
+            fi
+      - run:
+          name: Right yq?
+          command: |
+            bin/yq --version
+
 jobs:
   build:
     working_directory: ~/repo
@@ -6,21 +23,10 @@ jobs:
       - image: cimg/go:1.21
     steps:
       - checkout
+      - setup_yq
       - restore_cache:
           keys:
             - builder-config-{{ checksum "builder-config.yaml" }}
-      - run:
-          name: install dependencies
-          environment:
-            PYTHON_VERSION: 3.9
-          command: |
-            sudo apt-get update -qq
-            sudo apt-get install -y python3-pip
-            pip install yq
-            export GOARCH=$(go env GOARCH)
-            export GOOS=$(go env GOOS)
-            make bin/ocb
-            bin/ocb version
       - run:
           name: Run tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,21 +6,22 @@ executors:
       - image: cimg/go:1.21
 
 commands:
-  setup_yq:
-    description: "Ensure the right yq is installed"
+  setup_build_tools:
+    description: "Ensure the build tools are installed"
     steps:
       - run:
-          name: Maybe install Python yq
+          name: Ensure the right yq is installed
           command: |
             if ! bin/yq --version; then
               sudo apt-get update -qq
               sudo apt-get install -y python3-pip
               pip install yq
             fi
-      - run:
-          name: Right yq?
-          command: |
             bin/yq --version
+      - run:
+          name: Install build tools
+          command: make tools_exist
+
   setup_remote_and_local_docker:
     description: "Setup Docker and fiddle permissions when running local CI"
     steps:
@@ -38,9 +39,9 @@ jobs:
   test:
     executor: go-executor
     steps:
-      - setup_remote_and_local_docker
       - checkout
-      - setup_yq
+      - setup_remote_and_local_docker
+      - setup_build_tools
       - run:
           name: Run tests
           command: |
@@ -52,24 +53,31 @@ jobs:
   build:
     executor: go-executor
     steps:
-      - setup_remote_and_local_docker
       - checkout
-      - setup_yq
-      - attach_workspace:
-          at: .
+      - setup_remote_and_local_docker
+      - setup_build_tools
       - run:
-          name: Cross-compile binaries and build Docker image
+          name: Build for target test platform
+          command: make build
+      - run:
+          name: Test
+          command: make test
+      - run:
+          name: Cross-compile binaries and build local Docker image
           command: make all
-      - persist_to_workspace:
-          root: .
+      - save_cache:
+          key: go_build_cache-{{ .Environment.CIRCLE_SHA1 }}
           paths:
-            - dist
+            - /home/circleci/.cache/go-build
       - store_artifacts:
           path: dist
   publish_image:
     executor: go-executor
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - go_build_cache-{{ .Environment.CIRCLE_SHA1 }}
       - setup_remote_docker
       - attach_workspace:
           at: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,17 @@ jobs:
             - builder-config-{{ checksum "builder-config.yaml" }}
       - run:
           name: install dependencies
+          environment:
+            PYTHON_VERSION: 3.9
           command: |
+            sudo apt-get update -qq
+            sudo apt-get install -y python2  libbz2-dev  libreadline-dev libssl-dev openssl
+            curl https://pyenv.run | bash
+            export PYENV_ROOT=/home/circleci/.pyenv
+            export PATH=/home/circleci/.pyenv/shims:/home/circleci/.pyenv/bin:/home/circleci/.poetry/bin:$PATH
+            pyenv install $PYTHON_VERSION
+            pyenv global $PYTHON_VERSION
+            pip3 install yq
             export GOARCH=$(go env GOARCH)
             export GOOS=$(go env GOOS)
             make bin/ocb
@@ -20,6 +30,8 @@ jobs:
       - run:
           name: Run tests
           command: |
+            export PYENV_ROOT=/home/circleci/.pyenv
+            export PATH=/home/circleci/.pyenv/shims:/home/circleci/.pyenv/bin:/home/circleci/.poetry/bin:$PATH
             make test
       - run:
           name: Create artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,10 @@
 version: 2.1
+
+executors:
+  go-executor:
+    docker:
+      - image: cimg/go:1.21
+
 commands:
   setup_yq:
     description: "Ensure the right yq is installed"
@@ -17,27 +23,61 @@ commands:
             bin/yq --version
 
 jobs:
-  build:
+  test:
+    executor: go-executor
     working_directory: ~/repo
-    docker:
-      - image: cimg/go:1.21
     steps:
       - checkout
       - setup_yq
-      - restore_cache:
-          keys:
-            - builder-config-{{ checksum "builder-config.yaml" }}
       - run:
           name: Run tests
           command: |
             make test
+      - persist_to_workspace:
+          root: .
+          paths:
+            - cmd
+  build:
+    executor: go-executor
+    # working_directory: ~/repo
+    steps:
+      - checkout
+      - setup_remote_docker
+      - setup_yq
+      - attach_workspace:
+          at: .
       - run:
-          name: Create artifacts
-          command: |
-            mkdir -p /tmp/images;
-            cp build/otelcol_hny_$(go env GOOS)_$(go env GOARCH) /tmp/images;
-      - save_cache:
-          key: builder-config-{{ checksum "builder-config.yaml" }}
-          paths: build
+          name: Cross-compile binaries
+          command: make collector-bin
+      - run:
+          name: Build Docker image
+          command: make image
+      - persist_to_workspace:
+          root: .
+          paths:
+            - build
       - store_artifacts:
-          path: /tmp/images
+          path: build
+
+filters_always: &filters_always
+  filters:
+    tags:
+      only: /.*/
+
+filters_publish: &filters_publish
+  filters:
+    tags:
+      only: /^v[0-9].*/
+    branches:
+      ignore: /.*/
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - test:
+          <<: *filters_always
+      - build:
+          <<: *filters_always
+          requires:
+            - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,17 +47,25 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: Cross-compile binaries
-          command: make collector-bin
-      - run:
-          name: Build Docker image
-          command: make image
+          name: Cross-compile binaries and build Docker image
+          command: make all
       - persist_to_workspace:
           root: .
           paths:
-            - build
+            - dist
       - store_artifacts:
-          path: build
+          path: dist
+  publish_image:
+    executor: go-executor
+    steps:
+      - checkout
+      - setup_remote_docker
+      - attach_workspace:
+          at: .
+      - run:
+          name: Publish Docker images
+          command: |
+            make release
 
 filters_always: &filters_always
   filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,20 +36,6 @@ commands:
             ls -ls /var/run/docker*.sock
 
 jobs:
-  test:
-    executor: go-executor
-    steps:
-      - checkout
-      - setup_remote_and_local_docker
-      - setup_build_tools
-      - run:
-          name: Run tests
-          command: |
-            make test
-      - persist_to_workspace:
-          root: .
-          paths:
-            - cmd
   build:
     executor: go-executor
     steps:
@@ -102,12 +88,8 @@ workflows:
   version: 2
   build:
     jobs:
-      - test:
-          <<: *filters_always
       - build:
           <<: *filters_always
-          requires:
-            - test
       - publish_image:
           <<: *filters_publish
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,13 +15,8 @@ jobs:
             PYTHON_VERSION: 3.9
           command: |
             sudo apt-get update -qq
-            sudo apt-get install -y python2  libbz2-dev  libreadline-dev libssl-dev openssl
-            curl https://pyenv.run | bash
-            export PYENV_ROOT=/home/circleci/.pyenv
-            export PATH=/home/circleci/.pyenv/shims:/home/circleci/.pyenv/bin:/home/circleci/.poetry/bin:$PATH
-            pyenv install $PYTHON_VERSION
-            pyenv global $PYTHON_VERSION
-            pip3 install yq
+            sudo apt-get install -y python3-pip
+            pip install yq
             export GOARCH=$(go env GOARCH)
             export GOOS=$(go env GOOS)
             make bin/ocb
@@ -29,8 +24,6 @@ jobs:
       - run:
           name: Run tests
           command: |
-            export PYENV_ROOT=/home/circleci/.pyenv
-            export PATH=/home/circleci/.pyenv/shims:/home/circleci/.pyenv/bin:/home/circleci/.poetry/bin:$PATH
             make test
       - run:
           name: Create artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
     docker:
       - image: cimg/go:1.21
     steps:
+      - setup_remote_docker
       - checkout
       - restore_cache:
           keys:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.circleci/config-processed.yml
 /artifacts/*
+/bin/goreleaser*
 /bin/ko*
 /bin/ocb*
 /build/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /artifacts/*
+/bin/ocb*
 /build/*
 /test/tmp-*
 /dist/*

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /bin/ocb*
 /build/*
 /test/tmp-*
+/src
 /dist/*
 
 # GoLand IDEA

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 /bin/ocb*
 /build/*
 /test/tmp-*
-/src
+/cmd/otelcol_hny
 /dist/*
 
 # GoLand IDEA

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.circleci/config-processed.yml
 /artifacts/*
 /bin/ocb*
 /build/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.circleci/config-processed.yml
 /artifacts/*
+/bin/ko*
 /bin/ocb*
 /build/*
 /test/tmp-*

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,8 +1,5 @@
-# This is an example .goreleaser.yml file with some sensible defaults.
-# Make sure to check the documentation at https://goreleaser.com
+# Documentation for this config can be found at https://goreleaser.com
 
-# The lines below are called `modelines`. See `:help modeline`
-# Feel free to remove those if you don't want/need to use them.
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj
 
@@ -27,7 +24,7 @@ builds:
     no_unique_dist_dir: true
 
 snapshot:
-  version_template: "{{ incpatch .Version }}-dev-g{{ .ShortCommit }}"
+  version_template: "{{ .Env.VERSION }}"
 
 kos:
   - id: otelcol_hny
@@ -48,7 +45,8 @@ archives:
     format: tar.gz
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
-      {{ .ProjectName }}_
+      otelcol_hny_
+      {{- .Env.VERSION }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
@@ -59,7 +57,8 @@ archives:
       - goos: windows
         format: zip
     files:
-      - artifacts/honeycomb-metrics-config.yaml
+      - src: artifacts/honeycomb-metrics-config.yaml
+        dst: honeycomb-metrics-config.yaml
 
 nfpms:
   - package_name: otelcol_hny

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -83,6 +83,7 @@ nfpms:
       preremove: packaging/fpm/preuninstall.sh
 
 release:
+  draft: true
   extra_files:
     - glob: ./artifacts/honeycomb-metrics-config.yaml
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,95 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+
+# The lines below are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/need to use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
+
+builds:
+  - id: otelcol_hny
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    dir: ./cmd/otelcol_hny
+    binary: otelcol_hny_{{ .Os }}_{{ .Arch }}
+    no_unique_dist_dir: true
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-dev-g{{ .ShortCommit }}"
+
+kos:
+  - id: otelcol_hny
+    repository: ghcr.io/honeycombio/otelcol_hny
+    tags:
+      - "{{ .Version }}"
+      - "{{ if not .IsSnapshot }}{{ .Major }}.{{ .Minor }}{{ end }}"
+      - "{{ if not .IsSnapshot }}{{ .Major }}{{ end }}"
+      - "{{ if not .IsSnapshot }}latest{{ else }}dev{{ end }}"
+    base_import_paths: true
+    labels:
+      org.opencontainers.image.source: https://github.com/honeycombio/opentelemetry-collector-configs
+      org.opencontainers.image.licenses: Apache-2.0
+      org.opencontainers.image.revision: "{{ .FullCommit }}"
+
+archives:
+  - id: otelcol_hny
+    format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - artifacts/honeycomb-metrics-config.yaml
+
+nfpms:
+  - package_name: otelcol_hny
+    builds:
+      - otelcol_hny
+    vendor: Honeycomb.io
+    maintainer: Honeycomb Engineering <support@honeycomb.io>
+    license: Apache-2.0
+    formats:
+      - deb
+      - rpm
+    contents:
+      - src: packaging/fpm/otel-hny-collector.service
+        dst: /etc/systemd/system/otelcol_hny.service
+      - src: packaging/fpm/otel-hny-collector.conf
+        dst: /etc/otelcol_hny/otelcol_hny.conf
+      - src: artifacts/honeycomb-metrics-config.yaml
+        dst: /etc/otelcol_hny/config.yaml
+    scripts:
+      preinstall: packaging/fpm/preinstall.sh
+      postinstall: packaging/fpm/postinstall.sh
+      preremove: packaging/fpm/preuninstall.sh
+
+release:
+  extra_files:
+    - glob: ./artifacts/honeycomb-metrics-config.yaml
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,6 @@
+defaultPlatforms:
+- linux/arm64
+- linux/amd64
+builds:
+- id: otelcol_hny
+  dir: cmd/otelcol_hny

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+golang 1.21.13
+goreleaser 2.3.2

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,9 @@ vendor-fixtures/hostmetrics-receiver-metadata.yaml:
 	REMOTE_PATH='https://raw.githubusercontent.com/open-telemetry/opentelemetry-collector-contrib/141da3a5c4a1bf1570372e2890af383dd833167b/receiver/hostmetricsreceiver/metadata.yaml'; \
 	curl $$REMOTE_PATH | sed "1s|^|# DO NOT EDIT! This file is vendored from $${REMOTE_PATH}"$$'\\\n\\\n|' > vendor-fixtures/hostmetrics-receiver-metadata.yaml
 
+#: build the Honeycomb OpenTelemetry Collector for the current host's platform
+build: build/otelcol_hny_$(GOOS)_$(GOARCH)
+
 build/otelcol_hny_darwin_amd64:
 	GOOS=darwin GOARCH=amd64 $(MAKE) build-binary-internal
 

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,8 @@ collector-dist: dist/otel-hny-collector_$(VERSION)_amd64.deb dist/otel-hny-colle
 
 .PHONY: release
 release: artifacts/honeycomb-metrics-config.yaml $(GORELEASER)
-	$(GORELEASER) release $(MAYBE_SNAPSHOT) --clean
+	VERSION=$(VERSION) \
+		$(GORELEASER) release $(MAYBE_SNAPSHOT) --clean
 
 .PHONY: test
 test: integration_test
@@ -88,26 +89,30 @@ $(GO_SOURCES) &: $(SRC_DIR) $(OCB) builder-config.yaml
 #: build binary for the current platform
 build: $(GO_SOURCES) $(GORELEASER)
 	@echo "\n +++ Building $@\n"
+	VERSION=$(VERSION) \
 		$(GORELEASER) build $(MAYBE_SNAPSHOT) --clean --single-target
 
 .PHONY: build_all
 #: build binaries for all target platforms
 build_all: $(GO_SOURCES) $(GORELEASER)
 	@echo "\n +++ Building $@\n"
+	VERSION=$(VERSION) \
 		$(GORELEASER) build $(MAYBE_SNAPSHOT) --clean
 
 .PHONY: package
 #: build RPM and DEB packages
 package: $(GO_SOURCES) $(GORELEASER)
 	@echo "\n +++ Packaging \n"
-	$(GORELEASER) release $(MAYBE_SNAPSHOT) --clean --skip archive,ko,publish
+	VERSION=$(VERSION) \
+		$(GORELEASER) release $(MAYBE_SNAPSHOT) --clean --skip archive,ko,publish
 
 .PHONY: image
 KO_DOCKER_REPO ?= ko.local
 #: build a docker image; set KO_DOCKER_REPO to push to a registry
 image: $(GO_SOURCES) $(GORELEASER)
 	@echo "\n +++ Building image \n"
-	$(GORELEASER) release $(MAYBE_SNAPSHOT) --clean --skip archive,nfpm,publish
+	VERSION=$(VERSION) \
+		$(GORELEASER) release $(MAYBE_SNAPSHOT) --clean --skip archive,nfpm,publish --single-target
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ YQ=bin/yq
 OCB=bin/ocb
 GORELEASER=bin/goreleaser
 
+.PHONY: tools_exist
+tools_exist: $(YQ) $(OCB) $(GORELEASER)
+
 .PHONY: all
 all: config image
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION?=1.0.1
+VERSION?=$(shell git describe --tags --always)
 GOOS=$(shell go env GOOS)
 GOARCH=$(shell go env GOARCH)
 YQ=bin/yq

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ config: artifacts/honeycomb-metrics-config.yaml
 collector-bin: build/otelcol_hny_darwin_amd64 build/otelcol_hny_darwin_arm64 build/otelcol_hny_linux_amd64 build/otelcol_hny_linux_arm64 build/otelcol_hny_windows_amd64.exe
 
 .PHONY: collector-dist
-collector-dist: dist/otel-hny-collector_$(VERSION)_amd64.deb dist/otel-hny-collector_$(VERSION)_arm64.deb dist/otel-hny-collector_$(VERSION)_x86_64.rpm dist/otel-hny-collector_$(VERSION)_arm64.rpm
+collector-dist: dist/otel-hny-collector_$(VERSION)_amd64.deb dist/otel-hny-collector_$(VERSION)_arm64.deb dist/otel-hny-collector-$(VERSION)-x86_64.rpm dist/otel-hny-collector-$(VERSION)-arm64.rpm
 
 .PHONY: release
 release:
@@ -81,10 +81,10 @@ dist/otel-hny-collector_%_amd64.deb: build/otelcol_hny_linux_amd64
 dist/otel-hny-collector_%_arm64.deb: build/otelcol_hny_linux_arm64
 	PACKAGE=deb ARCH=arm64 VERSION=$* $(MAKE) build-package-internal
 
-dist/otel-hny-collector_%_x86_64.rpm: build/otelcol_hny_linux_amd64
+dist/otel-hny-collector-%-x86_64.rpm: build/otelcol_hny_linux_amd64
 	PACKAGE=rpm ARCH=amd64 VERSION=$* $(MAKE) build-package-internal
 
-dist/otel-hny-collector_%_arm64.rpm: build/otelcol_hny_linux_arm64
+dist/otel-hny-collector-%-arm64.rpm: build/otelcol_hny_linux_arm64
 	PACKAGE=rpm ARCH=arm64 VERSION=$* $(MAKE) build-package-internal
 
 .PHONY: build-package-internal

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ endif
 version:
 	@echo "CIRCLE_TAG: $(CIRCLE_TAG)"
 	@echo "VERSION (build info & packaging): $(VERSION)"
-	@echo "TAGS (for image labeling): $(TAGS)"
 
 # The Go platform info for the build host; cross-compile target are figured out differently
 GOOS=$(shell go env GOOS)
@@ -112,7 +111,7 @@ KO_DOCKER_REPO ?= ko.local
 image: $(GO_SOURCES) $(GORELEASER)
 	@echo "\n +++ Building image \n"
 	VERSION=$(VERSION) \
-		$(GORELEASER) release $(MAYBE_SNAPSHOT) --clean --skip archive,nfpm,publish --single-target
+		$(GORELEASER) release $(MAYBE_SNAPSHOT) --clean --skip archive,nfpm,publish
 
 .PHONY: clean
 clean:

--- a/bin/jq
+++ b/bin/jq
@@ -13,18 +13,26 @@
 
 set -e
 
-# Setup volume mounts for compose config and context
-if [ "${PWD}" != '/' ]; then
-    VOLUMES="-v ${PWD}:${PWD}"
+if command -v jq 2>&1 >/dev/null
+then
+    # jq is installed on the host ...
+    exec jq "$@"
+else
+    echo "\n⚠️ jq isn't on the path, so we'll try to use the docker image\n" >&2
+
+    # Setup volume mounts for compose config and context
+    if [ "${PWD}" != '/' ]; then
+        VOLUMES="-v ${PWD}:${PWD}"
+    fi
+
+    # Only allocate tty if we detect one
+    if [ -t 0 ] && [ -t 1 ]; then
+        DOCKER_RUN_OPTIONS="${DOCKER_RUN_OPTIONS} -t"
+    fi
+
+    # Always set -i to support piped and terminal input in run/exec
+    DOCKER_RUN_OPTIONS="${DOCKER_RUN_OPTIONS} -i"
+
+    # shellcheck disable=SC2086
+    exec docker run --rm ${DOCKER_RUN_OPTIONS} ${JQ_OPTIONS} ${VOLUMES} -w "${PWD}" --entrypoint jq "${YQ_IMAGE_TAG:-lscr.io/linuxserver/yq:latest}" "$@"
 fi
-
-# Only allocate tty if we detect one
-if [ -t 0 ] && [ -t 1 ]; then
-    DOCKER_RUN_OPTIONS="${DOCKER_RUN_OPTIONS} -t"
-fi
-
-# Always set -i to support piped and terminal input in run/exec
-DOCKER_RUN_OPTIONS="${DOCKER_RUN_OPTIONS} -i"
-
-# shellcheck disable=SC2086
-exec docker run --rm ${DOCKER_RUN_OPTIONS} ${JQ_OPTIONS} ${VOLUMES} -w "${PWD}" --entrypoint jq "${YQ_IMAGE_TAG:-lscr.io/linuxserver/yq:latest}" "$@"

--- a/bin/jq
+++ b/bin/jq
@@ -1,0 +1,30 @@
+#!/bin/sh
+#
+# This script will attempt to mirror the host paths by using volumes for the
+# following paths:
+#   * ${PWD}
+#
+# You can add additional volumes (or any docker run options) using
+# the ${JQ_OPTIONS} environment variable.
+#
+# You can set a specific image and tag, such as "lscr.io/linuxserver/yq:2.11.1-ls1"
+# using the $YQ_IMAGE_TAG environment variable (defaults to "lscr.io/linuxserver/yq:latest")
+#
+
+set -e
+
+# Setup volume mounts for compose config and context
+if [ "${PWD}" != '/' ]; then
+    VOLUMES="-v ${PWD}:${PWD}"
+fi
+
+# Only allocate tty if we detect one
+if [ -t 0 ] && [ -t 1 ]; then
+    DOCKER_RUN_OPTIONS="${DOCKER_RUN_OPTIONS} -t"
+fi
+
+# Always set -i to support piped and terminal input in run/exec
+DOCKER_RUN_OPTIONS="${DOCKER_RUN_OPTIONS} -i"
+
+# shellcheck disable=SC2086
+exec docker run --rm ${DOCKER_RUN_OPTIONS} ${JQ_OPTIONS} ${VOLUMES} -w "${PWD}" --entrypoint jq "${YQ_IMAGE_TAG:-lscr.io/linuxserver/yq:latest}" "$@"

--- a/bin/yq
+++ b/bin/yq
@@ -13,18 +13,31 @@
 
 set -e
 
-# Setup volume mounts for compose config and context
-if [ "${PWD}" != '/' ]; then
-    VOLUMES="-v ${PWD}:${PWD}"
+if command -v yq 2>&1 >/dev/null
+then
+    # yq is installed on the host ...
+    if yq --help | grep '\-\-yaml-output' --silent
+    then
+        exec yq "$@"
+    else
+        echo "\n🛑 The yq installed appears to be go-yq. We need python-yq: https://kislyuk.github.io/yq/#installation\n" >&2 && exit 1
+    fi
+else
+    echo "\n⚠️ yq isn't on the path, so we'll try to use the docker image\n" >&2
+
+    # Setup volume mounts for compose config and context
+    if [ "${PWD}" != '/' ]; then
+        VOLUMES="-v ${PWD}:${PWD}"
+    fi
+
+    # Only allocate tty if we detect one
+    if [ -t 0 ] && [ -t 1 ]; then
+        DOCKER_RUN_OPTIONS="${DOCKER_RUN_OPTIONS} -t"
+    fi
+
+    # Always set -i to support piped and terminal input in run/exec
+    DOCKER_RUN_OPTIONS="${DOCKER_RUN_OPTIONS} -i"
+
+    # shellcheck disable=SC2086
+    exec docker run --rm ${DOCKER_RUN_OPTIONS} ${YQ_OPTIONS} ${VOLUMES} -w "${PWD}" --entrypoint yq "${YQ_IMAGE_TAG:-lscr.io/linuxserver/yq:latest}" "$@"
 fi
-
-# Only allocate tty if we detect one
-if [ -t 0 ] && [ -t 1 ]; then
-    DOCKER_RUN_OPTIONS="${DOCKER_RUN_OPTIONS} -t"
-fi
-
-# Always set -i to support piped and terminal input in run/exec
-DOCKER_RUN_OPTIONS="${DOCKER_RUN_OPTIONS} -i"
-
-# shellcheck disable=SC2086
-exec docker run --rm ${DOCKER_RUN_OPTIONS} ${YQ_OPTIONS} ${VOLUMES} -w "${PWD}" --entrypoint yq "${YQ_IMAGE_TAG:-lscr.io/linuxserver/yq:latest}" "$@"

--- a/bin/yq
+++ b/bin/yq
@@ -1,0 +1,30 @@
+#!/bin/sh
+#
+# This script will attempt to mirror the host paths by using volumes for the
+# following paths:
+#   * ${PWD}
+#
+# You can add additional volumes (or any docker run options) using
+# the ${YQ_OPTIONS} environment variable.
+#
+# You can set a specific image and tag, such as "lscr.io/linuxserver/yq:2.11.1-ls1"
+# using the $YQ_IMAGE_TAG environment variable (defaults to "lscr.io/linuxserver/yq:latest")
+#
+
+set -e
+
+# Setup volume mounts for compose config and context
+if [ "${PWD}" != '/' ]; then
+    VOLUMES="-v ${PWD}:${PWD}"
+fi
+
+# Only allocate tty if we detect one
+if [ -t 0 ] && [ -t 1 ]; then
+    DOCKER_RUN_OPTIONS="${DOCKER_RUN_OPTIONS} -t"
+fi
+
+# Always set -i to support piped and terminal input in run/exec
+DOCKER_RUN_OPTIONS="${DOCKER_RUN_OPTIONS} -i"
+
+# shellcheck disable=SC2086
+exec docker run --rm ${DOCKER_RUN_OPTIONS} ${YQ_OPTIONS} ${VOLUMES} -w "${PWD}" --entrypoint yq "${YQ_IMAGE_TAG:-lscr.io/linuxserver/yq:latest}" "$@"

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -1,5 +1,5 @@
 dist:
-  module: github.com/honeycombio/opentelemetry-collector-configs
+  module: github.com/honeycombio/otelcol_hny
   description: "OpenTelemetry Collector for Honeycomb"
   otelcol_version: "0.98.0"
   output_path: build

--- a/packaging/fpm/deb/build.sh
+++ b/packaging/fpm/deb/build.sh
@@ -21,7 +21,7 @@ REPO_DIR="$( cd "$SCRIPT_DIR/../../../" && pwd )"
 VERSION="${1:-}"
 ARCH="${2:-"amd64"}"
 OUTPUT_DIR="${3:-"$REPO_DIR/dist/"}"
-OTELCOL_PATH="$REPO_DIR/build/otelcol_hny_linux_$ARCH"
+OTELCOL_PATH="$REPO_DIR/dist/otelcol_hny_linux_$ARCH"
 CONFIG_PATH="$REPO_DIR/artifacts/honeycomb-metrics-config.yaml"
 
 mkdir -p $OUTPUT_DIR

--- a/packaging/fpm/otel-hny-collector.conf
+++ b/packaging/fpm/otel-hny-collector.conf
@@ -2,4 +2,5 @@
 
 # Command-line options for the otel-hny-collector service.
 # Run `/usr/bin/otelcol-hny --help` to see all available options.
-OTELCOL_OPTIONS="--config=/etc/otel-hny-collector/config.yaml"
+OTELCOL_OPTIONS="--config=/etc/otelcol_hny/config.yaml"
+

--- a/packaging/fpm/rpm/build.sh
+++ b/packaging/fpm/rpm/build.sh
@@ -21,7 +21,7 @@ REPO_DIR="$( cd "$SCRIPT_DIR/../../../" && pwd )"
 VERSION="${1:-}"
 ARCH="${2:-"amd64"}"
 OUTPUT_DIR="${3:-"$REPO_DIR/dist/"}"
-OTELCOL_PATH="$REPO_DIR/build/otelcol_hny_linux_$ARCH"
+OTELCOL_PATH="$REPO_DIR/dist/otelcol_hny_linux_$ARCH"
 CONFIG_PATH="$REPO_DIR/artifacts/honeycomb-metrics-config.yaml"
 
 mkdir -p $OUTPUT_DIR

--- a/test/test.sh
+++ b/test/test.sh
@@ -7,11 +7,11 @@ orig_config_file="./artifacts/honeycomb-metrics-config.yaml"
 test_config_file=$(mktemp /tmp/test-config-XXXXXX)
 
 # make some modifications to config to make it testable
-yq -y '. * {
+bin/yq --yaml-output '. * {
   exporters: {
     file: {path: "'$output_file'"}
   },
-  receivers: { 
+  receivers: {
     hostmetrics: {
       collection_interval: "1s"
     }
@@ -46,7 +46,7 @@ wait $otelcol_pid
 echo "success!"
 
 # assert that metric names are correct
-found_names=$(jq -r '
+found_names=$(bin/jq -r '
   .resourceMetrics[] |
   .scopeMetrics[] |
   .metrics[] |
@@ -69,7 +69,7 @@ if (( ${metric_count} < 40 )); then
   exit 1
 fi
 
-unique_timestamps=$(jq -sr '
+unique_timestamps=$(bin/jq -sr '
     .[0].resourceMetrics[] |
     .scopeMetrics[] |
     .metrics[] |

--- a/test/test.sh
+++ b/test/test.sh
@@ -32,7 +32,7 @@ echo -n "running otelcol until we have data..."
 output_line_count () {
   wc -l $output_file | awk '{print $1}'
 }
-./build/otelcol_hny_$(go env GOOS)_$(go env GOARCH) --config $test_config_file >/dev/null 2>&1 &
+./dist/otelcol_hny_$(go env GOOS)_$(go env GOARCH) --config $test_config_file >/dev/null 2>&1 &
 otelcol_pid=$!
 
 while [ $(output_line_count) -lt 1 ]

--- a/vendor-fixtures/hostmetrics-receiver-metadata.yaml
+++ b/vendor-fixtures/hostmetrics-receiver-metadata.yaml
@@ -1,4 +1,4 @@
-# DO NOT EDIT! This file is vendored from https://raw.githubusercontent.com/open-telemetry/opentelemetry-collector/main/receiver/hostmetricsreceiver/metadata.yaml
+# DO NOT EDIT! This file is vendored from https://raw.githubusercontent.com/open-telemetry/opentelemetry-collector-contrib/141da3a5c4a1bf1570372e2890af383dd833167b/receiver/hostmetricsreceiver/metadata.yaml
 
 name: hostmetricsreceiver
 


### PR DESCRIPTION
* overhaul ocb, jq, and yq prereqs
  * use [a LinuxServer.io image](https://hub.docker.com/r/linuxserver/yq) for yq/jq to avoid managing a whole Python install
  * added scripts to a new ./bin directory to simplify the running of yq/jq
  * use Make to retrieve the necessary version of Collector to build upon; yq to query the version of the Collector in builder-config so that the version is declared in one place

* [ ] something something image publish 

