### PR TITLE
maint: allow multiple processor instances

### DIFF
--- a/usageprocessor/processor.go
+++ b/usageprocessor/processor.go
@@ -6,13 +6,19 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/processor"
 )
 
 type usageProcessor struct {
+	config *Config
+	set    processor.Settings
 }
 
-func newUsageProcessor() (*usageProcessor, error) {
-	return &usageProcessor{}, nil
+func newUsageProcessor(config *Config, set processor.Settings) (*usageProcessor, error) {
+	return &usageProcessor{
+		config: config,
+		set:    set,
+	}, nil
 }
 
 func (p *usageProcessor) processTraces(ctx context.Context, tracesData ptrace.Traces) (ptrace.Traces, error) {


### PR DESCRIPTION
## Which problem is this PR solving?

The processor is setup to allow only 1 instance no matter now many times it is specified. Since we're using the extension to report, I don't think a singleton pattern is necessary.

## Short description of the changes

- remove singleton patter
- update processor struct to save the config and settings

