### PR TITLE
fix: only add a signal if there's non-zero value

### DIFF
--- a/honeycombextension/extension.go
+++ b/honeycombextension/extension.go
@@ -43,12 +43,10 @@ const (
 	logs    = signal("logs")
 )
 
-func newBytesReceivedMap() map[signal][]datapoint {
-	return map[signal][]datapoint{
-		traces:  make([]datapoint, 0),
-		metrics: make([]datapoint, 0),
-		logs:    make([]datapoint, 0),
-	}
+type bytesReceivedMap map[signal][]datapoint
+
+func newBytesReceivedMap() bytesReceivedMap {
+	return make(map[signal][]datapoint, 0)
 }
 
 type datapoint struct {
@@ -60,7 +58,7 @@ type honeycombExtension struct {
 	config *Config
 	set    extension.Settings
 
-	bytesReceivedData map[signal][]datapoint
+	bytesReceivedData bytesReceivedMap
 	bytesReceivedMux  sync.Mutex
 	done              chan struct{}
 


### PR DESCRIPTION
## Which problem is this PR solving?

We were initializing the bytesReceivedMap with all signals. That makes checking whether the map is empty complicated. We should only add a signal if there's non-zero datapoints for that signal

## Short description of the changes
- initialize the bytesReceivedMap with zero value for a map
- 
## How to verify that this has the expected result
local testing