### PR TITLE
fix: add retry for sending usage report

### DIFF
--- a/honeycombextension/extension.go
+++ b/honeycombextension/extension.go
@@ -162,6 +162,29 @@ func (h *honeycombExtension) RecordLogsUsage(ld plog.Logs) {
 	h.bytesReceivedMux.Unlock()
 }
 
+func (h *honeycombExtension) sendUsageReport(data []byte) (retry bool) {
+	sendingChan, err := h.telemetryHandler.SendMessage(reportUsageMessageType, data)
+
+	switch {
+	case err == nil:
+		h.telemetryBuilder.HoneycombExtensionUsageReportSuccess.Add(context.Background(), 1)
+		h.set.Logger.Debug("Successfully sent usage report")
+		return false
+
+	case errors.Is(err, types.ErrCustomMessagePending):
+		h.telemetryBuilder.HoneycombExtensionUsageReportPending.Add(context.Background(), 1)
+		h.set.Logger.Debug("Message pending, waiting for completion")
+
+		<-sendingChan
+		return true
+
+	default:
+		h.telemetryBuilder.HoneycombExtensionUsageReportFailure.Add(context.Background(), 1)
+		h.set.Logger.Error("Failed to send message", zap.Error(err))
+		return false
+	}
+}
+
 func (h *honeycombExtension) reportUsage() {
 	t := time.NewTicker(time.Second * 30)
 	defer t.Stop()
@@ -181,23 +204,16 @@ func (h *honeycombExtension) reportUsage() {
 				continue
 			}
 
-			sendingChan, err := h.telemetryHandler.SendMessage(reportUsageMessageType, data)
-			switch {
-			case err == nil:
-				// Count successful report sent
-				h.telemetryBuilder.HoneycombExtensionUsageReportSuccess.Add(context.Background(), 1)
-			case errors.Is(err, types.ErrCustomMessagePending):
-				h.telemetryBuilder.HoneycombExtensionUsageReportPending.Add(context.Background(), 1)
-				<-sendingChan
-				continue
-			default:
-				h.telemetryBuilder.HoneycombExtensionUsageReportFailure.Add(context.Background(), 1)
-				h.set.Logger.Error("failed to send message", zap.Error(err))
+			shouldRetry := h.sendUsageReport(data)
+			// If the message was pending, wait for it to complete and retry once
+			if shouldRetry {
+				h.set.Logger.Debug("Pending message completed, retrying once")
+
+				h.sendUsageReport(data)
 			}
 		}
 	}
 }
-
 func (h *honeycombExtension) createUsageReport() ([]byte, error) {
 	// get a copy of the data and clear the map
 	h.bytesReceivedMux.Lock()


### PR DESCRIPTION
## Which problem is this PR solving?

OpAMP only allows one custom message being sent at any given time. If the previous message is still pending, the `SendMessage` will signal the sending of the pending message though a go channel. 
We should at least try to send the current message once if the previous message has completed.

## Short description of the changes
- add retry logic for current usage report if the previous pending message has been sent.

## How to verify that this has the expected result
unit test
