### PR TITLE
maint: remove logging exporter

### DIFF
--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -13,7 +13,7 @@ extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.98.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.98.0
 exporters:
-  - gomod: go.opentelemetry.io/collector/exporter/loggingexporter v0.98.0
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.98.0
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.98.0
   - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.98.0
   # file exporter needed for integration tests to run

--- a/config-generator.jq
+++ b/config-generator.jq
@@ -160,7 +160,7 @@ flatten(2) |
       }
     },
     "debug": {
-      "verbosity": ($ENV.LOG_LEVEL // "info")
+      "verbosity": ($ENV.LOG_LEVEL // "normal")
     }
   },
   "receivers": {

--- a/config-generator.jq
+++ b/config-generator.jq
@@ -159,8 +159,8 @@ flatten(2) |
         "x-honeycomb-dataset": "$HNY_DATASET",
       }
     },
-    "logging": {
-      "loglevel": ($ENV.LOG_LEVEL // "info")
+    "debug": {
+      "verbosity": ($ENV.LOG_LEVEL // "info")
     }
   },
   "receivers": {
@@ -217,7 +217,7 @@ flatten(2) |
       "metrics": {
         "receivers": ["hostmetrics"],
         "processors": ["metricstransform", "filter", "transform", "resourcedetection", "batch"],
-        "exporters": ["logging", "otlp"]
+        "exporters": ["debug", "otlp"]
       }
     }
   }


### PR DESCRIPTION
## Which problem is this PR solving?

The logging exporter was replaced by the debug exporter.

- Closes https://github.com/honeycombio/opentelemetry-collector-configs/issues/143

## How to verify that this has the expected result

CI passes